### PR TITLE
Fix for Reset charger button is not working

### DIFF
--- a/custom_components/solax_http/const.py
+++ b/custom_components/solax_http/const.py
@@ -48,6 +48,7 @@ class BaseHttpButtonEntityDescription(ButtonEntityDescription):
     allowedtypes: int = 0  # overload with ALLDEFAULT from plugin
     register: int = None
     command: int = None
+    scale: int = 1
     blacklist: list = None  # none or list of serial number prefixes
     value_function: callable = None  #  value = function(initval, descr, datadict)
 

--- a/custom_components/solax_http/entity_definitions.py
+++ b/custom_components/solax_http/entity_definitions.py
@@ -95,7 +95,12 @@ class SolaXEVChargerHttpSensorEntityDescription(BaseHttpSensorEntityDescription)
 
 BUTTON_TYPES = [
     SolaXEVChargerHttpButtonEntityDescription(
-        name="Reset", key="reset", register=0x618, icon="mdi:reset", allowedtypes=G1
+        name="Reset",
+        key="reset",
+        register=0x618,
+        scale=1,
+        icon="mdi:reset",
+        allowedtypes=G1
     )
     # SolaXEVChargerHttpButtonEntityDescription(
     #     name = "Sync RTC",


### PR DESCRIPTION
Following error is thrown when you try to click the Reset button. The issue is that the Button class does not contain scale attribute.
As part of this PR I added it so it corresponds with other entities.

I was also thinking of approach to adjust the _reverse_scale method to skip scaling in case there isn't this attribute defined, but rather opted for having the ability to use scale on that entity for future.


```
2026-03-30 13:59:12.250 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140212944850912] Unexpected exception
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 279, in handle_call_service
    response = await hass.services.async_call(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2817, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2860, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 835, in entity_service_call
    single_response = await _handle_entity_call(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
        hass, entity, func, data, call.context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 907, in _handle_entity_call
    result = await task
             ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/button/__init__.py", line 132, in _async_press_action
    await self.async_press()
  File "/config/custom_components/solax_http/button.py", line 74, in async_press
    await self.coordinator.write_register(
        self.entity_description, 1, always=True
    )
  File "/config/custom_components/solax_http/coordinator.py", line 132, in write_register
    payload = self.plugin.map_payload(entity_description, value)
  File "/config/custom_components/solax_http/plugin_solax_ev_charger.py", line 47, in map_payload
    payload = self._reverse_scale(descr, value)
  File "/config/custom_components/solax_http/plugin_base.py", line 50, in _reverse_scale
    if descr.scale is None:
       ^^^^^^^^^^^
AttributeError: 'SolaXEVChargerHttpButtonEntityDescription' object has no attribute 'scale'
```